### PR TITLE
Fix asset pathing

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function(manifestPath, options) {
     var replaceMap = {};
     for (var original in manifest) {
         var revved = manifest[original];
-        replaceMap[options.defaultRoot + '/' + original] = options.defaultRoot + revved;
+        replaceMap[options.defaultRoot + '/' + original] = options.defaultRoot + '/' + revved;
     }
 
     if (isStream) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-imagerev",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A image rev replace plugin for gulp",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
As of https://github.com/sindresorhus/gulp-rev/pull/18 paths in the manifest file no longer have a leading slash. As a result, this plugin no longer works - it fails to include the path separator between the root asset path and the asset path within the root. This patch addresses that, and bumps the version number to cause people using the plugin to update.

Also, HI TOMMY!
